### PR TITLE
Make dmenu.sh work on a Mac

### DIFF
--- a/dmenu.sh
+++ b/dmenu.sh
@@ -15,7 +15,7 @@
 ALL=`cat`
 
 # number the lines
-SPLITTED=$( echo $ALL | sed 's/ /\n/g' | awk -- '{print NR, $0 }' )
+SPLITTED=$( echo $ALL | tr ' ' '\n' | awk -- '{print NR, $0 }' )
 
 # prompt via dialog (output-fd=1 is so that dialog gui doesn't go to subshell)
 OUT=$( dialog --output-fd 1 --ok-label Select --menu Choose 0 50 22 $SPLITTED )
@@ -26,7 +26,7 @@ if [ "1" = "$EXIT_CODE" ] ; then exit 1 ; fi
 if [ "255" = "$EXIT_CODE" ] ; then exit 1 ; fi
 
 # extract text corresponding to numeric selection
-CHOSEN=$( echo $ALL | sed 's/ /\n/g' | awk -- "NR==$OUT {print \$0 }" )
+CHOSEN=$( echo $ALL | tr ' ' '\n' | awk -- "NR==$OUT {print \$0 }" )
 
 # print result
 echo $CHOSEN


### PR DESCRIPTION
I needed to tweak this to work on a Mac, because BSD `sed` doesn't interpret `\n` as a newline. So this happens:

![screen shot 2017-03-04 at 8 30 35 am](https://cloud.githubusercontent.com/assets/305268/23580432/bf10377c-00b6-11e7-8c16-2bd8a06ea07c.png)

The easiest thing to do to fix it is to simply replace `sed` with `tr`.

Thanks for sharing this repo! I was going to build the git branch switcher myself and then found this and it's great!